### PR TITLE
utils.yolo: compatibility with polygon labels

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -9,8 +9,8 @@ import logging
 import os
 import warnings
 
-import yaml
 import numpy as np
+import yaml
 
 import eta.core.utils as etau
 
@@ -27,7 +27,7 @@ def add_yolo_labels(
     label_field,
     labels_path,
     classes,
-    include_missing=False
+    include_missing=False,
 ):
     """Adds the given YOLO-formatted labels to the collection.
 
@@ -1025,14 +1025,13 @@ def load_yolo_annotations(txt_path, classes):
     Args:
         txt_path: the path to the annotations TXT file
         classes: the list of class label strings
-        
+
     Returns:
         a :class:`fiftyone.core.detections.Detections`
     """
     detections = []
     for row in _read_file_lines(txt_path):
         detection = _parse_yolo_row(row, classes)
-        c = detection.confidence
         detections.append(detection)
 
     return fol.Detections(detections=detections)
@@ -1093,7 +1092,7 @@ def _parse_yolo_row(row, classes):
 
         if len(row_vals) > 5:
             confidence = float(row_vals[5])
-            
+
     else: # polygon case
         vertices = list(map(float, row_vals[1:]))
         vertices = np.reshape(vertices, (-1, 2))

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with datasets in YOLO format.
 
-| Copyright 2017-2023, Voxel51, Inc.
+| Copyright 2017-2024, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -10,6 +10,7 @@ import os
 import warnings
 
 import yaml
+import numpy as np
 
 import eta.core.utils as etau
 
@@ -26,7 +27,7 @@ def add_yolo_labels(
     label_field,
     labels_path,
     classes,
-    include_missing=False,
+    include_missing=False
 ):
     """Adds the given YOLO-formatted labels to the collection.
 
@@ -1024,13 +1025,14 @@ def load_yolo_annotations(txt_path, classes):
     Args:
         txt_path: the path to the annotations TXT file
         classes: the list of class label strings
-
+        
     Returns:
         a :class:`fiftyone.core.detections.Detections`
     """
     detections = []
     for row in _read_file_lines(txt_path):
         detection = _parse_yolo_row(row, classes)
+        c = detection.confidence
         detections.append(detection)
 
     return fol.Detections(detections=detections)
@@ -1082,24 +1084,30 @@ def _get_yolo_v5_labels_path(image_path):
 
 def _parse_yolo_row(row, classes):
     row_vals = row.split()
-    target, xc, yc, w, h = row_vals[:5]
+    target = row_vals[0]
+    confidence = None
+    if len(row_vals) < 7: # box case
+        xc, yc, w, h = map(float, row_vals[1:5])
+        minx = xc - 0.5 * w
+        miny = yc - 0.5 * h
+
+        if len(row_vals) > 5:
+            confidence = float(row_vals[5])
+            
+    else: # polygon case
+        vertices = list(map(float, row_vals[1:]))
+        vertices = np.reshape(vertices, (-1, 2))
+        minx, miny = vertices.min(axis=0)
+        maxx, maxy = vertices.max(axis=0)
+        w = maxx - minx
+        h = maxy - miny
 
     try:
         label = classes[int(target)]
     except:
         label = str(target)
 
-    bounding_box = [
-        (float(xc) - 0.5 * float(w)),
-        (float(yc) - 0.5 * float(h)),
-        float(w),
-        float(h),
-    ]
-
-    if len(row_vals) > 5:
-        confidence = float(row_vals[5])
-    else:
-        confidence = None
+    bounding_box = [minx, miny, w, h]
 
     return fol.Detection(
         label=label, bounding_box=bounding_box, confidence=confidence


### PR DESCRIPTION
contour label support

## What changes are proposed in this pull request?

- Another common YOLO label format is not boxes as `x y w h`, but polygons as `x1 y1 ... xn yn`. 
- Before this patch, they were misinterpreted, so user (me in particular 😬 ) may stuck with such questions as "why evaluation scores are in the neighbourhood of zero" or "why my GT labels have confidence" or "why groundtruth labels are not fitting in the image"
- This patch reduces such stuckness: polygon labels still will be converted to boxes, but as proper envelope, so you can use them in visualization, evaluation, et cetera.

## How is this patch tested? If it is not, please explain why.

On custom datasets with both kinds of labels.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

I think this change deserves a little mention that users don't need change their labels outside of the library to reach compatibility with it.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
